### PR TITLE
Document get started process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # bike-grid-monorepo
+
+## Get Started
+
+This is a javascript / typescript project that uses pnpm, tested with `node v18.8.0 (npm v8.18.0)`. 
+
+To install dependencies, run `pnpm install`.
+
+To run locally, `pnpm --parallel dev`. This will start two services, one for the CMS, and one to view the BikeGridNow static site. Check your terminal output for development URLs.
+

--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -1,9 +1,8 @@
-# Sanity Blogging Content Studio
+# BikeGridNow CMS
 
-Congratulations, you have now installed the Sanity Content Studio, an open source real-time content editing environment connected to the Sanity backend.
+This project uses [Sanity Cms](https://www.sanity.io).
 
-Now you can do the following things:
-
+Check out these docs:
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
 - Check out the example frontend: [React/Next.js](https://github.com/sanity-io/tutorial-sanity-blog-react-next)
 - [Read the blog post about this template](https://www.sanity.io/blog/build-your-own-blog-with-sanity-and-next-js?utm_source=readme)

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -7,6 +7,7 @@
   "author": "Sam Wight <samuelwight@gmail.com>",
   "license": "UNLICENSED",
   "scripts": {
+    "dev": "sanity start",
     "start": "sanity start",
     "build": "sanity build"
   },

--- a/packages/site/README.md
+++ b/packages/site/README.md
@@ -4,40 +4,7 @@
 
 # bike-grid-frontend
 
-This repo contains the code for the website of Bike Grid Now, a group advocating for a 
+This directory contains the code for the website of Bike Grid Now, a group advocating for a 
 bike grid in Chicago. This website is open source (licensed under the MIT license) and created
 by volunteers. This repo can be copied and used as a starter site for anyone needing the ability
 to manage events, organizers, and more in a free CMS.
-
-This is a [SvelteKit](https://kit.svelte.dev/) app that uses Firebase for its backend.
-Content is hosted on Firebase currently.
-
-To setup, first clone the repo:
-
-```
-git clone git@github.com:bike-grid-now/bike-grid-frontend
-```
-
-Then install all the packages:
-
-```
-npm install
-```
-
-Finally, run the dev server:
-
-```
-npm run dev
-```
-
-To build the app for production:
-
-```
-npm run build
-```
-
-To deploy the app:
-
-```
-npm run deploy
-```


### PR DESCRIPTION
Fix up readme files, add get started instructions, adds a dev command for sanity so all projects can be started from the root directory with `pnpm --parallel dev`.